### PR TITLE
ci(release): generate updater .sig and harden windows upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          SRC=$(ls "src-tauri/target/release/bundle/nsis"/*.exe.sig | head -1)
-          test -f "$SRC" || { echo "::error::missing nsis .sig"; exit 1; }
+          SRC=$(find src-tauri/target/release/bundle/nsis -maxdepth 1 -type f -name "*.exe.sig" | head -1)
+          if [ -z "$SRC" ]; then
+            echo "::error::missing nsis .sig — check that createUpdaterArtifacts is set and TAURI_SIGNING_PRIVATE_KEY is provided"
+            ls -la src-tauri/target/release/bundle/nsis/ || true
+            exit 1
+          fi
           gh release upload "${{ github.ref_name }}" "$SRC" \
             --repo "${{ github.repository }}" --clobber
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,6 +33,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": "v1Compatible",
     "macOS": {
       "signingIdentity": "Developer ID Application: Ethan Morisset (VJL93TUP2X)",
       "providerShortName": "VJL93TUP2X",


### PR DESCRIPTION
## Summary
- Enable `createUpdaterArtifacts: "v1Compatible"` so Windows builds produce `.exe.sig` (Tauri 2 no longer generates them by default).
- Make the Windows `.sig` upload step robust via `find`, with a clear error if no `.sig` was produced.

## Test plan
- [ ] Merge → retag v0.3.3 → confirm `.exe.sig` lands on the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)