### PR TITLE
fix(cla): store signatures on dedicated branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/blueshork/maestro-deck/blob/main/CLA.md'
-          branch: 'main'
+          branch: 'cla-signatures'
           allowlist: 'dependabot[bot],blueshork'
           remote-organization-name: ''
           remote-repository-name: ''


### PR DESCRIPTION
Fixes the CLA Assistant 'Repository rule violations' error by directing signature
   commits to the unprotected cla-signatures orphan branch instead of main.