### PR TITLE
chore(security): add gitleaks pre-commit hook with auto-install via make

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,35 @@
+# Gitleaks configuration for Maestro Deck.
+# Extends the default ruleset and whitelists known safe patterns
+# identified during the pre-release security audit.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Allowlist for known-safe placeholders and public tokens"
+
+paths = [
+  '''pnpm-lock\.yaml''',
+  '''Cargo\.lock''',
+  '''.*\.test\.(ts|tsx|rs)$''',
+  '''.*\.spec\.(ts|tsx)$''',
+  '''dist/.*''',
+  '''coverage/.*''',
+  '''src-tauri/target/.*''',
+]
+
+regexes = [
+  # UI placeholders shown to users — not real keys
+  '''placeholder=["']sk-ant-…["']''',
+  '''placeholder=['"]\{"type":"service_account"''',
+  # Test fixture intentionally invalid private key
+  '''-----BEGIN PRIVATE KEY-----\\nnot-real\\n-----END PRIVATE KEY-----''',
+  # Documentation placeholders
+  '''APPLE_PASSWORD=["']app-specific-password["']''',
+  '''APPLE_ID=["']ton@email\.com["']''',
+  '''APPLE_TEAM_ID=["']TON_TEAM_ID["']''',
+  # SonarCloud public project badge token (read-only, by design public)
+  '''token=ad460cd2309b7ca91f43029430daf2d31295d3d1''',
+  # Tauri updater public key (must be embedded in the binary)
+  '''dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk''',
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,15 @@ pnpm install
 pnpm tauri:dev
 ```
 
+`pnpm install` runs `make setup-hooks` automatically, which:
+
+- Installs the Lefthook git hooks (`pre-commit`, `pre-push`).
+- Auto-installs [gitleaks](https://github.com/gitleaks/gitleaks) on macOS via Homebrew (used by the `pre-commit` hook to detect committed secrets locally).
+
+On **Linux**, install gitleaks manually from the [official releases](https://github.com/gitleaks/gitleaks/releases) if you want local pre-commit scanning. On **Windows** (without `make`), the hooks still install via a fallback — gitleaks must then be installed manually (e.g. `scoop install gitleaks` or `winget install gitleaks`).
+
+Either way, the hook skips gracefully if gitleaks is missing, and GitHub server-side push protection blocks secrets at push time as a safety net.
+
 The dev command launches the Tauri shell with hot-reload for both the React frontend (`src/`) and the Rust backend (`src-tauri/`).
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: help install dev build preview tauri-dev tauri-build tauri-release lint typecheck test test-watch format format-check check clean
+.PHONY: help install setup-hooks dev build preview tauri-dev tauri-build tauri-release lint typecheck test test-watch format format-check check clean
 
 help:
 	@echo "Maestro Deck - available commands:"
 	@echo "  make install       Install dependencies (pnpm install)"
+	@echo "  make setup-hooks   Install git hooks + gitleaks (auto-detects OS)"
 	@echo "  make dev           Start the Vite dev server (web)"
 	@echo "  make build         Build web app (tsc + vite build)"
 	@echo "  make preview       Preview the web build"
@@ -20,6 +21,19 @@ help:
 
 install:
 	pnpm install
+
+setup-hooks:
+	@pnpm exec lefthook install >/dev/null 2>&1 || true
+	@if command -v gitleaks >/dev/null 2>&1; then \
+		echo "✓ gitleaks already installed"; \
+	elif [ "$$(uname)" = "Darwin" ] && command -v brew >/dev/null 2>&1; then \
+		echo "→ Installing gitleaks via Homebrew..."; \
+		brew install gitleaks || echo "⚠️  Failed to install gitleaks via brew. Install manually: https://github.com/gitleaks/gitleaks#installing"; \
+	elif [ "$$(uname)" = "Linux" ] && command -v apt-get >/dev/null 2>&1; then \
+		echo "⚠️  Install gitleaks manually on Linux: https://github.com/gitleaks/gitleaks/releases"; \
+	else \
+		echo "⚠️  gitleaks not auto-installed for your OS. Install manually: https://github.com/gitleaks/gitleaks#installing"; \
+	fi
 
 dev:
 	pnpm dev

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,9 @@ pre-commit:
       glob: "src-tauri/**/*.rs"
       run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
 
+    gitleaks:
+      run: command -v gitleaks >/dev/null && gitleaks protect --staged --redact --no-banner || echo "⚠️  gitleaks not installed — skipping local secret scan (install with 'brew install gitleaks')"
+
 pre-push:
   parallel: true
   commands:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "prepare": "lefthook install",
+    "prepare": "make setup-hooks 2>/dev/null || lefthook install",
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev --features devtools",


### PR DESCRIPTION
  setup-hooks

# Pull request

## What

<!-- One or two sentences describing what this PR changes. -->

## Why

<!-- The motivation. Link to any related issue. -->

Closes #

## How

<!-- Brief overview of the approach, especially anything non-obvious. -->

## Checklist

- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(inspector): ...`)
- [ ] `pnpm typecheck && pnpm lint` passes
- [ ] `cargo fmt --check && cargo clippy -- -D warnings` passes
- [ ] `cargo test --lib` passes
- [ ] New behavior is covered by a test (or a clear note why not)
- [ ] Docs / comments updated where the change is non-obvious
- [ ] No new `unwrap()` / `expect()` in production code paths
