### PR TITLE
fix(deps): bump jsonwebtoken from 9 to 10

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ tauri-plugin-process = "2.0"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 # JWT signing for Vertex Oauth2
-jsonwebtoken = "9"
+jsonwebtoken = "10"
 
 # HTTP for token exchange
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }


### PR DESCRIPTION
## Summary

- Bumps `jsonwebtoken` from `9` (resolves to 9.3.1) to `10` (resolves to 10.4.0) in `src-tauri/Cargo.toml`
- Fixes the Type Confusion vulnerability flagged by Dependabot (#7 / CVE Moderate)
- No code changes required — the `encode`, `EncodingKey`, and `Header` APIs used in `vertex.rs` are unchanged between v9 and v10

## Test plan

- [ ] `cargo check` passes (verified locally)
- [ ] CI rust-quality job passes (clippy + fmt + check)