### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -1,3 +1,16 @@
+# What's New in v0.7.0
+
+## Visual regression
+- **Screenshot bank** — capture reference screenshots and compare later runs against them to catch unintended visual changes, with a side-by-side image diff.
+
+## Performance
+- **Perf panel improvements** and a configurable **`APP_ID`** so performance metrics target the right app.
+
+## Maintenance
+- Dependency and CI updates (js-yaml, vite, actions/checkout).
+
+---
+
 # What's New in v0.5.5
 
 ## iOS

--- a/LICENSE
+++ b/LICENSE
@@ -15,7 +15,7 @@ Additional Use Grant: You may use the Licensed Work in production,
                       (in original or modified form) as a commercial
                       product or as part of a commercial offering.
 
-Change Date:          2030-06-28
+Change Date:          2030-07-08
 
 Change License:       Apache License, Version 2.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maestro-deck",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "description": "Source-available visual IDE for Maestro mobile tests",
   "license": "BUSL-1.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestro-deck"
-version = "0.6.0"
+version = "0.7.0"
 description = "Source-available visual IDE for Maestro mobile tests"
 authors = ["Ethan Morisset <blueshork.dev@gmail.com>"]
 license = "BUSL-1.1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Maestro Deck",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "identifier": "dev.blueshork.maestrodeck",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump to v0.7.0 + changelog.

Highlights: screenshot bank (visual regression), perf panel + APP_ID config, dependency/CI bumps.

Merging this puts the release commit on main so the `v0.7.0` tag can be cut (Windows CI enforces tag-reachable-from-main). Mac bundle is built + signed locally after merge.